### PR TITLE
Fixing an error with the session handler

### DIFF
--- a/src/RoutingServiceProvider.php
+++ b/src/RoutingServiceProvider.php
@@ -25,7 +25,7 @@ class RoutingServiceProvider extends BaseRoutingServiceProvider
                 $routes, $app->rebinding('request', $this->requestRebinder())
             );
 
-            $url->setSessionResolver(function ($app) {
+            $url->setSessionResolver(function () use ($app) {
                 return $app['session'];
             });
 


### PR DESCRIPTION
Sometimes the `$app` is not given in the closure, which results in an error.