### PR TITLE
Added capability to specify which routes should be considered to add …

### DIFF
--- a/config/trailingslash.php
+++ b/config/trailingslash.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'included' => '*'
+];

--- a/src/RoutingServiceProvider.php
+++ b/src/RoutingServiceProvider.php
@@ -6,6 +6,13 @@ use Illuminate\Routing\RoutingServiceProvider as BaseRoutingServiceProvider;
 
 class RoutingServiceProvider extends BaseRoutingServiceProvider
 {
+    public function boot()
+    {
+        $this->publishes([
+            __DIR__.'/../config/trailingslash.php' => config_path('trailingslash.php'),
+        ]);
+    }
+
     /**
      * Register the URL generator service.
      *
@@ -13,6 +20,10 @@ class RoutingServiceProvider extends BaseRoutingServiceProvider
      */
     public function register()
     {
+        $this->mergeConfigFrom(
+            __DIR__.'/../config/trailingslash.php', 'trailingslash'
+        );
+
         $this->registerUrlGenerator();
     }
 

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -17,6 +17,14 @@ class UrlGenerator extends BaseUrlGenerator
      */
     public function format($root, $path, $route = null)
     {
-        return parent::format($root, $path, $route).(str_contains($path, '#') ? '' : '/');
+        $match = [$path];
+
+        if(!is_null($route)) {
+            $match = array_merge([$route->uri,$route->action['as']], $match);
+        }
+
+        $matchRoute = config('trailingslash.included','*') == '*' || (is_array($match) && array_intersect($match, config('trailingslash.included','*')));
+
+        return parent::format($root, $path, $route).(str_contains($path, '#') || !$matchRoute ? '' : '/');
     }
 }


### PR DESCRIPTION
Added a config file to configure which routes should have the trailing slash.

Default value is ***** which means that trailing slash must be added to all routes (which was the default behaviour).
You can publish the config file and specify an array of routes. It will match final urls, route names and route patterns