### PR TITLE
Fix signature error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "fsasvari/laravel-trailing-slash",
+    "name": "streetyo/laravel-trailing-slash",
     "description": "The package that adds redirection with trailing slash to Laravel framework.",
     "keywords": ["redirect", "laravel", "php"],
     "license": "MIT",


### PR DESCRIPTION
By default, the method compares the url from $request->url(), which does not have a slash, and the generated signature, which used a url with a slash, because of this, the method returns false and fails the request with an error.