### PR TITLE
Fix Laravel 12 compatibility for hasCorrectSignature()

### DIFF
--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaravelTrailingSlash;
 
 use Illuminate\Http\Request;
+use Closure;
 use Illuminate\Routing\UrlGenerator as BaseUrlGenerator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -32,7 +33,7 @@ class UrlGenerator extends BaseUrlGenerator
      *
      * @return bool
      */
-    public function hasCorrectSignature(Request $request, $absolute = true, array $ignoreQuery = [])
+    public function hasCorrectSignature(Request $request, $absolute = true, Closure|array $ignoreQuery = [])
     {
         $ignoreQuery[] = 'signature';
 


### PR DESCRIPTION
This PR updates the method signature of `hasCorrectSignature()` to match Laravel 12 compatibility.  
Fixes error due to `Closure|array` type hint requirement.